### PR TITLE
fix: :bug: fix: :bug: feat: :sparkles: feat: Add optional hourId field

### DIFF
--- a/src/context/plans/dto/get-clients-assignal.dto.ts
+++ b/src/context/plans/dto/get-clients-assignal.dto.ts
@@ -35,4 +35,8 @@ export class GetClientsAssignalDto {
   @IsOptional()
   @IsString()
   CI?: string;
+
+  @IsOptional()
+  @IsString()
+  hourId?: string;
 }

--- a/src/context/plans/plans.controller.ts
+++ b/src/context/plans/plans.controller.ts
@@ -82,6 +82,7 @@ export class PlansController {
       getClientsAssignalDto.email,
       getClientsAssignalDto.name,
       getClientsAssignalDto.CI,
+      getClientsAssignalDto.hourId,
     );
   }
 

--- a/src/context/plans/plans.service.ts
+++ b/src/context/plans/plans.service.ts
@@ -104,6 +104,7 @@ export class PlansService {
     name?: string,
     email?: string,
     CI?: string,
+    hourId?: string,
   ) {
     const filters: any = {};
     const offset = (page - 1) * limit;
@@ -120,6 +121,8 @@ export class PlansService {
       filters.CI = { $regex: CI, $options: "i" };
     }
 
+    const hour = await this.scheduleRepository.findById(hourId);
+
     // Obtener todos los clientes con sus planes y schedules (sin paginar aún)
     const clients = await this.getClientsWithPlansAndSchedules(filters);
 
@@ -128,8 +131,13 @@ export class PlansService {
       const planDays = client.plan?.days || 0;
       const assignedDays =
         client.assignedSchedules?.map((s: any) => s.day) || [];
+      const hourClients = hour._doc.clients || [];
 
-      return assignedDays.length < planDays && client._doc.role === "User";
+      return (
+        assignedDays.length < planDays &&
+        client._doc.role === "User" &&
+        !hourClients.includes(client._doc._id)
+      );
     });
 
     // **IMPORTANTE:** Obtener el total antes de la paginación


### PR DESCRIPTION
This pull request includes changes to the `Plans` context to add support for filtering clients by `hourId`. The most important changes include updating the DTO, controller, and service to handle the new `hourId` parameter, as well as modifying the filtering logic to consider the `hourId` when retrieving clients.

Changes to support `hourId`:

* [`src/context/plans/dto/get-clients-assignal.dto.ts`](diffhunk://#diff-f6a16c4ee20f7c9d1a1ceb3a0d4d4fcef8703101455bb0379e5cfad0beac60ddR38-R41): Added `hourId` as an optional string parameter in the `GetClientsAssignalDto` class.

* [`src/context/plans/plans.controller.ts`](diffhunk://#diff-1827c858289888341fe664b753847e0452d5816cc8dca86de8bc04db9c957ed4R85): Updated the `PlansController` to include `hourId` when calling the service method.

* `src/context/plans/plans.service.ts`: 
  - Added `hourId` as an optional string parameter in the service method.
  - Modified the filtering logic to retrieve the hour from the `scheduleRepository` using `hourId`.
  - Updated the client filtering logic to exclude clients already assigned to the specified hour.